### PR TITLE
Fix logo overlap when menu goes to the left

### DIFF
--- a/app/assets/stylesheets/modules/aside_info.css.scss
+++ b/app/assets/stylesheets/modules/aside_info.css.scss
@@ -500,6 +500,10 @@
   @media only screen and (max-width: 768px) {
     margin: 60px auto 30px;
   }
+
+  @media only screen and (min-width: 1150px) and (max-width: 1320px) {
+    margin: 80px auto 30px;
+  }
   
   img {
     z-index: 1;


### PR DESCRIPTION
There was an issue when the menu (in >768px resolutions) goes to the left, the MagmaConf logo was overlapping with the menu.
