### PR TITLE
Fix exceding padding in mobile

### DIFF
--- a/app/assets/stylesheets/modules/main_menu.css.scss
+++ b/app/assets/stylesheets/modules/main_menu.css.scss
@@ -87,6 +87,10 @@
 
       &.link-more-padding {
         padding: 0 20px;
+
+        @media only screen and (max-width: 768px) {
+          padding: 0;
+        }
       }
     }
 


### PR DESCRIPTION
There was an option with extra padding in mobile, now it's fixed.
**Before**
![screen shot 2016-12-13 at 9 54 44 am](https://cloud.githubusercontent.com/assets/2782816/21147335/4c94bc94-c11a-11e6-818f-56fc88e23038.png)

**After**
![screen shot 2016-12-13 at 9 55 21 am](https://cloud.githubusercontent.com/assets/2782816/21147346/514430da-c11a-11e6-8f90-e8e6720bd966.png)
